### PR TITLE
Control stuck on Running state for resource type targets account on gov cloud. closes #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Release History
 
+## 1.0.4 [2025-12-04]
+
+Fixed: Control stuck on Running state for resource type targets account on gov and china cloud.
+
 ## 1.0.3 [2025-09-17]
 
 Fixed: Resolved an issue where controls encountering non-fatal errors were not retried and remained in the handling state indefinitely.

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const setAWSEnvVars = ($) => {
     }
   }
 
-  const region =
+  let region =
     $.item?.turbot?.custom?.aws?.regionName ??
     $.item?.turbot?.metadata?.aws?.regionName ??
     $.item?.metadata?.aws?.regionName;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@turbot/guardrails-lib-fn",
   "author": "Turbot HQ, Inc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Guardrails Lib Fn.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Issue Description
Problem
Control stuck on Running state as in mod we change the Input partition path to include
`$.item.metadata.aws.partition` to use `$.item.metadata.partition` and during that step based on partition
we set the default region since region is a const we are not able to set the default region on gov or china paritition
it is thowing Typeerror

##  issue
<img width="2312" height="254" alt="image" src="https://github.com/user-attachments/assets/27189b14-8b0f-4749-aee2-9afa3df38ad9" />

## After Fix
<img width="2636" height="265" alt="image" src="https://github.com/user-attachments/assets/c1655adf-a91c-447e-9d07-eb1b0d05e909" />
<img width="1222" height="524" alt="image" src="https://github.com/user-attachments/assets/4bebd9a8-07f3-4591-8604-92fbfbf83e37" />
