### PR TITLE
Fix missing return statement in gfn success path

### DIFF
--- a/index.js
+++ b/index.js
@@ -598,7 +598,7 @@ function gfn(asyncHandler) {
       });
 
       // Finalize handling
-      await finalize(event, context, init, finalError, finalResult);
+      return await finalize(event, context, init, finalError, finalResult);
     } catch (err) {
       if (init && init.turbot) {
         if (err && err.fatal) {


### PR DESCRIPTION
## Summary

- Add missing `return` statement in the `gfn` function's success path (line 601)
- Aligns success path behavior with the error path which already has the return statement

## Details

The success path was missing a return statement, causing the handler to return `undefined` instead of the value from `finalize()`. This impacted TURBOT_TEST mode where the handler should return `{ result, turbot: processEvent }` for test assertions.

**Before:**
```javascript
await finalize(event, context, init, finalError, finalResult);
```

**After:**
```javascript
return await finalize(event, context, init, finalError, finalResult);
```

## Test plan

- [ ] Verify existing tests pass
- [ ] Confirm TURBOT_TEST mode now returns the expected `{ result, turbot: processEvent }` structure

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)