### PR TITLE
Fix crash loop when unhandled exception occurs outside Lambda invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,15 +485,22 @@ const finalize = async (event, context, init, err, result) => {
   }
 
   if (!init || !init.turbot) {
-    // can't do anything here .. have to just silently return
+    // Can't do anything without a turbot object - return early to prevent crash loop.
+    // This can happen if an unhandled exception occurs outside of a Lambda invocation
+    // (e.g., during cold start or between invocations) when _init is undefined.
     console.error("Error reported but no turbot object, unable to send anything back", { error: err });
+    return;
   }
 
   // DO NOT log error here - we've persisted the large commands, let's avoid adding
   // any new information into the cargo
 
-  // Do not wait for empty callback look to terminate the process
-  context.callbackWaitsForEmptyEventLoop = false;
+  // Do not wait for empty callback loop to terminate the process.
+  // Guard against undefined context which can occur if finalize() is called from
+  // unhandledExceptionHandler before a Lambda invocation has set _context.
+  if (context) {
+    context.callbackWaitsForEmptyEventLoop = false;
+  }
 
   // If in test mode, then do not publish to SNS. Instead, morph the response to include
   // both the turbot information and the raw result so they can be used for assertions.

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,37 @@ describe("@turbot/gfn", function () {
   before(() => { process.env.TURBOT_TEST = true; });
   after(() => { delete process.env.TURBOT_TEST; });
 
+  describe("unhandled exception handling", function () {
+    it("should not crash when unhandledRejection occurs outside Lambda invocation", async function () {
+      // This tests the fix for issue #25 - crash loop when unhandled rejection
+      // occurs outside Lambda invocation context.
+      //
+      // Before the fix, finalize() would crash with:
+      // "Cannot set properties of undefined (setting 'callbackWaitsForEmptyEventLoop')"
+      // when context was undefined, causing an infinite crash loop.
+      //
+      // The fix adds:
+      // 1. Early return when init/turbot is undefined
+      // 2. Guard on context before accessing callbackWaitsForEmptyEventLoop
+      //
+      // This test verifies the handler completes without throwing. If this test
+      // passes, it proves finalize() handles the edge case gracefully.
+
+      const testError = new Error("Test unhandled rejection");
+
+      // Emit the event - before the fix, this would crash and cause infinite loop.
+      // After the fix, it should complete gracefully.
+      process.emit("unhandledRejection", testError);
+
+      // Give async handler time to execute
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // If we reach here without the test framework catching an uncaught exception,
+      // the fix is working. The test passing IS the assertion.
+      assert.ok(true, "unhandledRejection handler completed without crashing");
+    });
+  });
+
   // Minimal event so initialize() can build Turbot without SNS
   const event = {
     meta: { runType: "control", processId: "p-1" },


### PR DESCRIPTION
## Summary

Fixes two bugs in `finalize()` that caused an infinite crash loop when an unhandled exception occurred outside a Lambda invocation context.

### Bug 1: Missing return statement (line 487-492)
The code checked for `!init || !init.turbot` and logged an error, but continued execution despite the comment saying "silently return".

### Bug 2: No guard on context access (line 496)
`context.callbackWaitsForEmptyEventLoop = false` crashed when `context` was undefined.

## Root Cause

When an unhandled rejection occurs outside a Lambda invocation (e.g., during cold start or between invocations):

1. `_context` is undefined (only set inside `gfn()` during active invocation)
2. `unhandledExceptionHandler` calls `finalize(_event, _context, _init, err, null)`
3. `finalize()` logs "no turbot object" but doesn't return
4. Line 496 crashes: `Cannot set properties of undefined (setting 'callbackWaitsForEmptyEventLoop')`
5. This triggers another exception → handler called again → infinite loop

## Changes

- Added `return` statement after the "no turbot object" error log
- Added guard `if (context)` before accessing `context.callbackWaitsForEmptyEventLoop`
- Added explanatory comments for both fixes

## Risk Assessment

**Low risk** - These are defensive guards that:
- Only affect error handling paths, not normal execution
- Prevent crashes rather than changing behavior
- The `return` makes the code match its documented intent

## Test plan

- [x] Existing tests pass
- [ ] Deploy to test environment and verify no regression in normal Lambda execution
- [ ] Verify crash loop no longer occurs when unhandled rejection happens outside invocation

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)